### PR TITLE
Add gas limit check

### DIFF
--- a/src/contracts/StakedAaveV3.sol
+++ b/src/contracts/StakedAaveV3.sol
@@ -119,7 +119,7 @@ contract StakedAaveV3 is StakedTokenV3, IStakedAaveV3 {
     bytes4 selector = IGhoVariableDebtTokenTransferHook
       .updateDiscountDistribution
       .selector;
-    uint256 gasLimit = 12_101;
+    uint256 gasLimit = 90_000;
     assembly ('memory-safe') {
       // solhint-disable-line no-inline-assembly
       let ptr := mload(0x40)

--- a/src/contracts/StakedAaveV3.sol
+++ b/src/contracts/StakedAaveV3.sol
@@ -120,6 +120,7 @@ contract StakedAaveV3 is StakedTokenV3, IStakedAaveV3 {
       .updateDiscountDistribution
       .selector;
     uint256 gasLimit = 220_000;
+
     /// @solidity memory-safe-assembly
     assembly {
       // solhint-disable-line no-inline-assembly

--- a/src/contracts/StakedAaveV3.sol
+++ b/src/contracts/StakedAaveV3.sol
@@ -68,40 +68,6 @@ contract StakedAaveV3 is StakedTokenV3, IStakedAaveV3 {
     return _claimRewardsAndStakeOnBehalf(from, to, amount);
   }
 
-  /// @notice Assembly implementation of the gas limited call to avoid return gas bomb,
-  /// moreover call to a destructed plugin would also revert even inside try-catch block in Solidity 0.8.17
-  function _updateDiscountDistribution(
-    address ghoDebtToken,
-    address from,
-    address to,
-    uint256 fromBalanceBefore,
-    uint256 toBalanceBefore,
-    uint256 amount
-  ) internal {
-    bytes4 selector = IGhoVariableDebtTokenTransferHook
-      .updateDiscountDistribution
-      .selector;
-    uint256 gasLimit = 200_000; // TODO: put correct gas limit
-    assembly ('memory-safe') {
-      // solhint-disable-line no-inline-assembly
-      let ptr := mload(0x40)
-      mstore(ptr, selector)
-      mstore(add(ptr, 0x04), from)
-      mstore(add(ptr, 0x24), to)
-      mstore(add(ptr, 0x44), fromBalanceBefore)
-      mstore(add(ptr, 0x64), toBalanceBefore)
-      mstore(add(ptr, 0x84), amount)
-
-      let gasLeft := gas()
-      if iszero(call(gasLimit, ghoDebtToken, 0, ptr, 0xA4, 0, 0)) {
-        if lt(div(mul(gasLeft, 63), 64), gasLimit) {
-          returndatacopy(ptr, 0, returndatasize())
-          revert(ptr, returndatasize())
-        }
-      }
-    }
-  }
-
   /**
    * - On _transfer, it updates discount, rewards & delegation for both "from" and "to"
    * - On _mint, only for _to
@@ -127,18 +93,32 @@ contract StakedAaveV3 is StakedTokenV3, IStakedAaveV3 {
       amount
     );
 
-    IGhoVariableDebtTokenTransferHook cachedGhoDebtToken = ghoDebtToken;
-    if (address(cachedGhoDebtToken) != address(0)) {
-      try
-        _updateDiscountDistribution(
-          cachedGhoDebtToken,
-          from,
-          to,
-          fromBalanceBefore,
-          toBalanceBefore,
-          amount
-        )
-      {} catch (bytes memory) {}
+    address cachedGhoDebtToken = address(ghoDebtToken);
+    if (cachedGhoDebtToken != address(0)) {
+      /// @notice Assembly implementation of the gas limited call to avoid return gas bomb,
+      /// moreover call to a destructed plugin would also revert even inside try-catch block in Solidity 0.8.17
+      bytes4 selector = IGhoVariableDebtTokenTransferHook
+        .updateDiscountDistribution
+        .selector;
+      uint256 gasLimit = 12_101;
+      assembly ('memory-safe') {
+        // solhint-disable-line no-inline-assembly
+        let ptr := mload(0x40)
+        mstore(ptr, selector)
+        mstore(add(ptr, 0x04), from)
+        mstore(add(ptr, 0x24), to)
+        mstore(add(ptr, 0x44), fromBalanceBefore)
+        mstore(add(ptr, 0x64), toBalanceBefore)
+        mstore(add(ptr, 0x84), amount)
+
+        let gasLeft := gas()
+        if iszero(call(gasLimit, cachedGhoDebtToken, 0, ptr, 0xA4, 0, 0)) {
+          if lt(div(mul(gasLeft, 63), 64), gasLimit) {
+            returndatacopy(ptr, 0, returndatasize())
+            revert(ptr, returndatasize())
+          }
+        }
+      }
     }
   }
 }

--- a/src/contracts/StakedAaveV3.sol
+++ b/src/contracts/StakedAaveV3.sol
@@ -119,7 +119,7 @@ contract StakedAaveV3 is StakedTokenV3, IStakedAaveV3 {
     bytes4 selector = IGhoVariableDebtTokenTransferHook
       .updateDiscountDistribution
       .selector;
-    uint256 gasLimit = 90_000;
+    uint256 gasLimit = 220_000;
     assembly ('memory-safe') {
       // solhint-disable-line no-inline-assembly
       let ptr := mload(0x40)

--- a/src/contracts/StakedAaveV3.sol
+++ b/src/contracts/StakedAaveV3.sol
@@ -107,7 +107,7 @@ contract StakedAaveV3 is StakedTokenV3, IStakedAaveV3 {
   }
 
   /// @notice Assembly implementation of the gas limited call to avoid return gas bomb,
-  /// moreover call to a destructed plugin would also revert even inside try-catch block in Solidity 0.8.17
+  /// moreover call would also revert even inside try-catch block in Solidity 0.8.17
   function _updateDiscountDistribution(
     address cachedGhoDebtToken,
     address from,

--- a/src/contracts/StakedTokenV3.sol
+++ b/src/contracts/StakedTokenV3.sol
@@ -97,7 +97,7 @@ contract StakedTokenV3 is
   {
     // brick initialize
     lastInitializedRevision = REVISION();
-    uint256 decimals = IERC20Metadata(address(stakedToken)).decimals();
+    uint256 decimals = 18; //IERC20Metadata(address(stakedToken)).decimals(); TODO: this doesnt work on tests
     LOWER_BOUND = 10 ** decimals;
   }
 

--- a/src/contracts/StakedTokenV3.sol
+++ b/src/contracts/StakedTokenV3.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: agpl-3.0
 pragma solidity ^0.8.0;
 
-import 'forge-std/console.sol';
 import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {IERC20Metadata} from 'openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import {BaseDelegation} from 'aave-token-v3/BaseDelegation.sol';
@@ -97,9 +96,8 @@ contract StakedTokenV3 is
     )
   {
     // brick initialize
-    console.log('aave', address(stakedToken));
     lastInitializedRevision = REVISION();
-    uint256 decimals = 18; //IERC20Metadata(address(stakedToken)).decimals();
+    uint256 decimals = IERC20Metadata(address(stakedToken)).decimals();
     LOWER_BOUND = 10 ** decimals;
   }
 

--- a/src/contracts/StakedTokenV3.sol
+++ b/src/contracts/StakedTokenV3.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: agpl-3.0
 pragma solidity ^0.8.0;
 
+import 'forge-std/console.sol';
 import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {IERC20Metadata} from 'openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import {BaseDelegation} from 'aave-token-v3/BaseDelegation.sol';
@@ -96,8 +97,9 @@ contract StakedTokenV3 is
     )
   {
     // brick initialize
+    console.log('aave', address(stakedToken));
     lastInitializedRevision = REVISION();
-    uint256 decimals = 18; //IERC20Metadata(address(stakedToken)).decimals(); TODO: this doesnt work on tests
+    uint256 decimals = 18; //IERC20Metadata(address(stakedToken)).decimals();
     LOWER_BOUND = 10 ** decimals;
   }
 

--- a/tests/StkAaveGhoDistribution.t.sol
+++ b/tests/StkAaveGhoDistribution.t.sol
@@ -6,32 +6,85 @@ import {GovHelpers} from 'aave-helpers/GovHelpers.sol';
 import {StakedTokenV3} from '../src/contracts/StakedTokenV3.sol';
 import {IInitializableAdminUpgradeabilityProxy} from '../src/interfaces/IInitializableAdminUpgradeabilityProxy.sol';
 import {BaseTest} from './BaseTest.sol';
+import {StakedAaveV3} from '../src/contracts/StakedAaveV3.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {AaveMisc} from 'aave-address-book/AaveMisc.sol';
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {IGhoVariableDebtTokenTransferHook} from '../src/interfaces/IGhoVariableDebtTokenTransferHook.sol';
 
-contract GhoDistributionGasTest is BaseTest {
+contract GhoDistributionGasTest is Test, StakedAaveV3 {
+  address ghoToken = 0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f;
+
   function setUp() public {
-    _setUp(true);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 18635596);
+  }
+
+  constructor()
+    StakedAaveV3(
+      IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING),
+      IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING),
+      172800,
+      AaveMisc.ECOSYSTEM_RESERVE,
+      GovernanceV3Ethereum.EXECUTOR_LVL_1,
+      3155692600
+    )
+  {
+    ghoDebtToken = IGhoVariableDebtTokenTransferHook(ghoToken);
   }
 
   function test_transferWithCorrectGas() public {
-    uint256 amount = 10 ether;
-    uint256 gasLimit = 300_000 - 13_000;
+    uint256 gasLimit = 300_000 - 64_000;
 
-    address user = address(1234);
+    address from = address(1234);
+    address to = address(123415);
+    uint256 fromBalance = 10 ether;
+    uint256 toBalance = 10 ether;
 
-    deal(address(STAKE_CONTRACT.STAKED_TOKEN()), user, amount);
-    console.log('balance', STAKE_CONTRACT.STAKED_TOKEN().balanceOf(user));
+    uint256 amount = 1 ether;
 
-    hoax(user);
-    STAKE_CONTRACT.STAKED_TOKEN().approve(
-      address(STAKE_CONTRACT),
-      type(uint256).max
+    this.updateDiscountDistribution{gas: gasLimit}(
+      ghoToken,
+      from,
+      to,
+      fromBalance,
+      toBalance,
+      amount
     );
-    console.log(
-      'balance',
-      STAKE_CONTRACT.STAKED_TOKEN().allowance(user, address(STAKE_CONTRACT))
-    );
+    //    address user = address(1234);
+    //
+    //    deal(address(STAKE_CONTRACT.STAKED_TOKEN()), user, amount);
+    //    console.log('balance', STAKE_CONTRACT.STAKED_TOKEN().balanceOf(user));
+    //
+    //    vm.startPrank(user);
+    //    STAKE_CONTRACT.STAKED_TOKEN().approve(
+    //      address(STAKE_CONTRACT),
+    //      type(uint256).max
+    //    );
+    //    console.log(
+    //      'balance',
+    //      STAKE_CONTRACT.STAKED_TOKEN().allowance(user, address(STAKE_CONTRACT))
+    //    );
+    //
+    //    STAKE_CONTRACT.stake{gas: gasLimit}(user, amount);
+    //    vm.stopPrank();
+  }
 
-    hoax(user);
-    STAKE_CONTRACT.stake{gas: gasLimit}(user, amount);
+  function updateDiscountDistribution(
+    address cachedGhoDebtToken,
+    address from,
+    address to,
+    uint256 fromBalanceBefore,
+    uint256 toBalanceBefore,
+    uint256 amount
+  ) external {
+    _updateDiscountDistribution(
+      cachedGhoDebtToken,
+      from,
+      to,
+      fromBalanceBefore,
+      toBalanceBefore,
+      amount
+    );
   }
 }

--- a/tests/StkAaveGhoDistribution.t.sol
+++ b/tests/StkAaveGhoDistribution.t.sol
@@ -12,12 +12,16 @@ import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
 import {AaveMisc} from 'aave-address-book/AaveMisc.sol';
 import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
 import {IGhoVariableDebtTokenTransferHook} from '../src/interfaces/IGhoVariableDebtTokenTransferHook.sol';
+import {IERC20Metadata} from 'openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 
 contract GhoDistributionGasTest is Test, StakedAaveV3 {
-  address ghoToken = 0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f;
+  address ghoToken = 0x786dBff3f1292ae8F92ea68Cf93c30b34B1ed04B; //0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 18635596);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 18636130);
+    console.log(
+      IERC20Metadata(address(AaveV3EthereumAssets.AAVE_UNDERLYING)).decimals()
+    );
   }
 
   constructor()
@@ -34,15 +38,16 @@ contract GhoDistributionGasTest is Test, StakedAaveV3 {
   }
 
   function test_transferWithCorrectGas() public {
-    uint256 gasLimit = 300_000 - 64_000;
+    uint256 gasLimit = 4_000;
 
-    address from = address(1234);
+    address from = 0xE831C8903de820137c13681E78A5780afDdf7697;
     address to = address(123415);
     uint256 fromBalance = 10 ether;
-    uint256 toBalance = 10 ether;
+    uint256 toBalance = 0 ether;
 
     uint256 amount = 1 ether;
 
+    vm.expectRevert();
     this.updateDiscountDistribution{gas: gasLimit}(
       ghoToken,
       from,
@@ -51,23 +56,16 @@ contract GhoDistributionGasTest is Test, StakedAaveV3 {
       toBalance,
       amount
     );
-    //    address user = address(1234);
-    //
-    //    deal(address(STAKE_CONTRACT.STAKED_TOKEN()), user, amount);
-    //    console.log('balance', STAKE_CONTRACT.STAKED_TOKEN().balanceOf(user));
-    //
-    //    vm.startPrank(user);
-    //    STAKE_CONTRACT.STAKED_TOKEN().approve(
-    //      address(STAKE_CONTRACT),
-    //      type(uint256).max
-    //    );
-    //    console.log(
-    //      'balance',
-    //      STAKE_CONTRACT.STAKED_TOKEN().allowance(user, address(STAKE_CONTRACT))
-    //    );
-    //
-    //    STAKE_CONTRACT.stake{gas: gasLimit}(user, amount);
-    //    vm.stopPrank();
+
+    // expect error but not revert
+    this.updateDiscountDistribution(
+      ghoToken,
+      from,
+      to,
+      fromBalance,
+      toBalance,
+      amount
+    );
   }
 
   function updateDiscountDistribution(

--- a/tests/StkAaveGhoDistribution.t.sol
+++ b/tests/StkAaveGhoDistribution.t.sol
@@ -47,8 +47,6 @@ contract GhoDistributionGasTest is BaseTest, StakedAaveV3 {
   }
 
   function test_transferWithCorrectGasLimit() public {
-    uint256 gasLimit = 4_000;
-
     address from = 0xE831C8903de820137c13681E78A5780afDdf7697;
     address to = address(123415);
     uint256 fromBalance = 10 ether;
@@ -57,6 +55,19 @@ contract GhoDistributionGasTest is BaseTest, StakedAaveV3 {
     uint256 amount = 1 ether;
     // expect execution to complete
     vm.startPrank(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+    vm.expectCallMinGas(
+      ghoToken,
+      0,
+      220_000,
+      abi.encodeWithSelector(
+        IGhoVariableDebtTokenTransferHook.updateDiscountDistribution.selector,
+        from,
+        to,
+        fromBalance,
+        toBalance,
+        amount
+      )
+    );
     vm.expectEmit(true, true, false, true);
     emit Transfer(address(0), from, 41185113828714);
     vm.expectEmit(true, true, false, true);
@@ -80,8 +91,6 @@ contract GhoDistributionGasTest is BaseTest, StakedAaveV3 {
 
   // test to make external call revert but due other reason different than out of gas
   function test_transferWithCorrectGasButErrorsOut() public {
-    uint256 gasLimit = 4_000;
-
     address from = 0xE831C8903de820137c13681E78A5780afDdf7697;
     address to = address(123415);
     uint256 fromBalance = 10 ether;

--- a/tests/StkAaveGhoDistribution.t.sol
+++ b/tests/StkAaveGhoDistribution.t.sol
@@ -46,7 +46,7 @@ contract GhoDistributionGasTest is BaseTest, StakedAaveV3 {
     ghoDebtToken = IGhoVariableDebtTokenTransferHook(ghoToken);
   }
 
-  function test_transferWithCorrectGas() public {
+  function test_transferWithCorrectGasLimit() public {
     uint256 gasLimit = 4_000;
 
     address from = 0xE831C8903de820137c13681E78A5780afDdf7697;
@@ -55,27 +55,6 @@ contract GhoDistributionGasTest is BaseTest, StakedAaveV3 {
     uint256 toBalance = 0 ether;
 
     uint256 amount = 1 ether;
-
-    vm.expectRevert();
-    this.updateDiscountDistribution{gas: gasLimit}(
-      ghoToken,
-      from,
-      to,
-      fromBalance,
-      toBalance,
-      amount
-    );
-
-    // expect error but not revert
-    this.updateDiscountDistribution(
-      ghoToken,
-      from,
-      to,
-      fromBalance,
-      toBalance,
-      amount
-    );
-
     // expect execution to complete
     vm.startPrank(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
     vm.expectEmit(true, true, false, true);
@@ -97,6 +76,51 @@ contract GhoDistributionGasTest is BaseTest, StakedAaveV3 {
       amount
     );
     vm.stopPrank();
+  }
+
+  // test to make external call revert but due other reason different than out of gas
+  function test_transferWithCorrectGasButErrorsOut() public {
+    uint256 gasLimit = 4_000;
+
+    address from = 0xE831C8903de820137c13681E78A5780afDdf7697;
+    address to = address(123415);
+    uint256 fromBalance = 10 ether;
+    uint256 toBalance = 0 ether;
+
+    uint256 amount = 1 ether;
+
+    // expect error but not revert
+    this.updateDiscountDistribution(
+      ghoToken,
+      from,
+      to,
+      fromBalance,
+      toBalance,
+      amount
+    );
+  }
+
+  // test to make external call revert due to not enough gas
+  function test_transferWithIncorrectGas() public {
+    uint256 insufficientGasLimit = 4_000;
+
+    address from = 0xE831C8903de820137c13681E78A5780afDdf7697;
+    address to = address(123415);
+    uint256 fromBalance = 10 ether;
+    uint256 toBalance = 0 ether;
+
+    uint256 amount = 1 ether;
+
+    // reverts because there is not enough gas
+    vm.expectRevert();
+    this.updateDiscountDistribution{gas: insufficientGasLimit}(
+      ghoToken,
+      from,
+      to,
+      fromBalance,
+      toBalance,
+      amount
+    );
   }
 
   function updateDiscountDistribution(

--- a/tests/StkAaveGhoDistribution.t.sol
+++ b/tests/StkAaveGhoDistribution.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity ^0.8.0;
+
+import 'forge-std/Test.sol';
+import {GovHelpers} from 'aave-helpers/GovHelpers.sol';
+import {StakedTokenV3} from '../src/contracts/StakedTokenV3.sol';
+import {IInitializableAdminUpgradeabilityProxy} from '../src/interfaces/IInitializableAdminUpgradeabilityProxy.sol';
+import {BaseTest} from './BaseTest.sol';
+
+contract GhoDistributionGasTest is BaseTest {
+  function setUp() public {
+    _setUp(true);
+  }
+
+  function test_transferWithCorrectGas() public {
+    uint256 amount = 10 ether;
+    uint256 gasLimit = 300_000 - 13_000;
+
+    address user = address(1234);
+
+    deal(address(STAKE_CONTRACT.STAKED_TOKEN()), user, amount);
+    console.log('balance', STAKE_CONTRACT.STAKED_TOKEN().balanceOf(user));
+
+    hoax(user);
+    STAKE_CONTRACT.STAKED_TOKEN().approve(
+      address(STAKE_CONTRACT),
+      type(uint256).max
+    );
+    console.log(
+      'balance',
+      STAKE_CONTRACT.STAKED_TOKEN().allowance(user, address(STAKE_CONTRACT))
+    );
+
+    hoax(user);
+    STAKE_CONTRACT.stake{gas: gasLimit}(user, amount);
+  }
+}

--- a/tests/StkAaveGhoDistribution.t.sol
+++ b/tests/StkAaveGhoDistribution.t.sol
@@ -22,6 +22,14 @@ contract BaseTest is Test {
 contract GhoDistributionGasTest is BaseTest, StakedAaveV3 {
   address ghoToken = 0x786dBff3f1292ae8F92ea68Cf93c30b34B1ed04B;
 
+  event Mint(
+    address indexed caller,
+    address indexed onBehalfOf,
+    uint256 value,
+    uint256 balanceIncrease,
+    uint256 index
+  );
+
   function setUp() public {}
 
   constructor()
@@ -68,7 +76,18 @@ contract GhoDistributionGasTest is BaseTest, StakedAaveV3 {
       amount
     );
 
+    // expect execution to complete
     vm.startPrank(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+    vm.expectEmit(true, true, false, true);
+    emit Transfer(address(0), from, 41185113828714);
+    vm.expectEmit(true, true, false, true);
+    emit Mint(
+      address(0),
+      from,
+      41185113828714,
+      41185113828714,
+      1008020889040822120071191507
+    );
     _updateDiscountDistribution(
       ghoToken,
       from,

--- a/tests/StkAaveGhoDistribution.t.sol
+++ b/tests/StkAaveGhoDistribution.t.sol
@@ -15,7 +15,7 @@ import {IGhoVariableDebtTokenTransferHook} from '../src/interfaces/IGhoVariableD
 import {IERC20Metadata} from 'openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 
 contract GhoDistributionGasTest is Test, StakedAaveV3 {
-  address ghoToken = 0x786dBff3f1292ae8F92ea68Cf93c30b34B1ed04B; //0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f;
+  address ghoToken = 0x786dBff3f1292ae8F92ea68Cf93c30b34B1ed04B;
 
   function setUp() public {
     vm.createSelectFork(vm.rpcUrl('mainnet'), 18636130);

--- a/tests/StkAaveGhoDistribution.t.sol
+++ b/tests/StkAaveGhoDistribution.t.sol
@@ -5,7 +5,6 @@ import 'forge-std/Test.sol';
 import {GovHelpers} from 'aave-helpers/GovHelpers.sol';
 import {StakedTokenV3} from '../src/contracts/StakedTokenV3.sol';
 import {IInitializableAdminUpgradeabilityProxy} from '../src/interfaces/IInitializableAdminUpgradeabilityProxy.sol';
-import {BaseTest} from './BaseTest.sol';
 import {StakedAaveV3} from '../src/contracts/StakedAaveV3.sol';
 import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
@@ -14,17 +13,19 @@ import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
 import {IGhoVariableDebtTokenTransferHook} from '../src/interfaces/IGhoVariableDebtTokenTransferHook.sol';
 import {IERC20Metadata} from 'openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 
-contract GhoDistributionGasTest is Test, StakedAaveV3 {
+contract BaseTest is Test {
+  constructor() {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 18636130);
+  }
+}
+
+contract GhoDistributionGasTest is BaseTest, StakedAaveV3 {
   address ghoToken = 0x786dBff3f1292ae8F92ea68Cf93c30b34B1ed04B;
 
-  function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 18636130);
-    console.log(
-      IERC20Metadata(address(AaveV3EthereumAssets.AAVE_UNDERLYING)).decimals()
-    );
-  }
+  function setUp() public {}
 
   constructor()
+    BaseTest()
     StakedAaveV3(
       IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING),
       IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING),
@@ -66,6 +67,17 @@ contract GhoDistributionGasTest is Test, StakedAaveV3 {
       toBalance,
       amount
     );
+
+    vm.startPrank(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+    _updateDiscountDistribution(
+      ghoToken,
+      from,
+      to,
+      fromBalance,
+      toBalance,
+      amount
+    );
+    vm.stopPrank();
   }
 
   function updateDiscountDistribution(


### PR DESCRIPTION
On this pr we are updating the call to GHO debt token inside a try catch with assembly code so as to revert in the case that an Out Of Gas situation is detected. This way stk functionality will not get affected by errors inside the updateDiscountDistribution call, unless its OOG.
OOG error is catched as it could be actively exploited by an attacker, affecting the correct accounting of the discount