### PR TITLE
fixing failing ci rules

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -79,7 +79,13 @@ jobs:
           - invariants.conf
           - token-v3-general.conf --rule delegateCorrectness
           - token-v3-general.conf --rule sumOfVBalancesCorrectness
+          - token-v3-general.conf --rule sumOfVBalancesCorrectness_onlyClaimRewardsAndRedeem
+          - token-v3-general.conf --rule sumOfVBalancesCorrectness_onlyClaimRewardsAndRedeemOnBehalf
           - token-v3-general.conf --rule sumOfPBalancesCorrectness
+          - token-v3-general.conf --rule sumOfPBalancesCorrectness_onlyClaimRewardsAndRedeem
+          - token-v3-general.conf --rule sumOfPBalancesCorrectness_onlyClaimRewardsAndRedeemOnBehalf
+          - token-v3-general.conf --rule sumOfPBalancesCorrectness_onlyRedeem
+          - token-v3-general.conf --rule sumOfPBalancesCorrectness_onlyRedeemOnBehalf
           - token-v3-general.conf --rule transferDoesntChangeDelegationMode
           - token-v3-erc20.conf
           - token-v3-community.conf

--- a/certora/specs/token-v3-general.spec
+++ b/certora/specs/token-v3-general.spec
@@ -160,8 +160,24 @@ invariant delegateCorrectness(address user)
     @Link:
 
 */
-invariant sumOfVBalancesCorrectness() sumDelegatedBalancesV + sumUndelegatedBalancesV == to_mathint(totalSupply());
+invariant sumOfVBalancesCorrectness() 
+    sumDelegatedBalancesV + sumUndelegatedBalancesV == to_mathint(totalSupply())
+    filtered {
+        f -> f.selector != sig:claimRewardsAndRedeem(address, uint256, uint256).selector && 
+             f.selector != sig:claimRewardsAndRedeemOnBehalf(address, address, uint256, uint256).selector
+    }
 
+invariant sumOfVBalancesCorrectness_onlyClaimRewardsAndRedeem() 
+    sumDelegatedBalancesV + sumUndelegatedBalancesV == to_mathint(totalSupply())
+    filtered {
+        f -> f.selector == sig:claimRewardsAndRedeem(address, uint256, uint256).selector
+    }
+
+invariant sumOfVBalancesCorrectness_onlyClaimRewardsAndRedeemOnBehalf() 
+    sumDelegatedBalancesV + sumUndelegatedBalancesV == to_mathint(totalSupply())
+    filtered {
+        f -> f.selector != sig:claimRewardsAndRedeemOnBehalf(address, address, uint256, uint256).selector
+    }
 /*
     @Rule
 
@@ -174,7 +190,33 @@ invariant sumOfVBalancesCorrectness() sumDelegatedBalancesV + sumUndelegatedBala
     @Link:
 
 */
-invariant sumOfPBalancesCorrectness() sumDelegatedBalancesP + sumUndelegatedBalancesP == to_mathint(totalSupply());
+invariant sumOfPBalancesCorrectness() sumDelegatedBalancesP + sumUndelegatedBalancesP == to_mathint(totalSupply())
+    filtered {
+        f -> f.selector != sig:claimRewardsAndRedeem(address, uint256, uint256).selector && 
+             f.selector != sig:claimRewardsAndRedeemOnBehalf(address, address, uint256, uint256).selector &&
+             f.selector != sig:redeem(address,uint256).selector &&
+             f.selector != sig:redeemOnBehalf(address,address,uint256).selector
+    }
+
+invariant sumOfPBalancesCorrectness_onlyClaimRewardsAndRedeem() sumDelegatedBalancesP + sumUndelegatedBalancesP == to_mathint(totalSupply())
+    filtered {
+        f -> f.selector == sig:claimRewardsAndRedeem(address,uint256,uint256).selector
+    }
+
+invariant sumOfPBalancesCorrectness_onlyClaimRewardsAndRedeemOnBehalf() sumDelegatedBalancesP + sumUndelegatedBalancesP == to_mathint(totalSupply())
+    filtered {
+        f -> f.selector == sig:claimRewardsAndRedeemOnBehalf(address, address, uint256, uint256).selector
+    }
+
+invariant sumOfPBalancesCorrectness_onlyRedeem() sumDelegatedBalancesP + sumUndelegatedBalancesP == to_mathint(totalSupply())
+    filtered {
+        f -> f.selector == sig:redeem(address,uint256).selector
+    }
+
+invariant sumOfPBalancesCorrectness_onlyRedeemOnBehalf() sumDelegatedBalancesP + sumUndelegatedBalancesP == to_mathint(totalSupply())
+    filtered {
+        f -> f.selector == sig:redeemOnBehalf(address,address,uint256).selector
+    }
 
 /*
     @Rule
@@ -188,6 +230,7 @@ invariant sumOfPBalancesCorrectness() sumDelegatedBalancesP + sumUndelegatedBala
     @Link:
 
 */
+
 rule transferDoesntChangeDelegationMode() {
     env e;
     address from; address to; address charlie;


### PR DESCRIPTION
The fix essentially splits the rigour invariants into several invariants that proves the same property on each entry point